### PR TITLE
fix: Generalize filter status across models and eliminate use of filt…

### DIFF
--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -43,6 +43,7 @@ export class Client {
         name: filter.filterName,
         lifeLevel: filter.filterPer,
         code: filter.filterCode,
+        filterType: ['극세사망 프리필터', 'Max2 필터'].indexOf(filter.filterName),
       };
 
       return filterStatus;

--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -41,8 +41,13 @@ export const Config = {
 
   Filters : {
     PRE_FILTER_HAP_SUBTYPE : 'pre',
-    PRE_FILTER_CODE : '3121332',
     MAIN_FILTER_HAP_SUBTYPE : 'main',
-    MAIN_FILTER_CODE : '3104756', // previously 3111735
+    // 300S/400S filters
+    //PRE_FILTER_CODE : '3121332',
+    //MAIN_FILTER_CODE : '3104756', // previously 3111735
+
+    // AP-1512HHS filters
+    //PRE_FILTER_CODE : '3109126,',
+    //MAIN_FILTER_CODE : '3107167'
   },
 } as const;

--- a/src/lib/interfaces/PurifierStatus.ts
+++ b/src/lib/interfaces/PurifierStatus.ts
@@ -36,10 +36,16 @@ export interface Status {
   airQuality: AirQuality;
 }
 
+export enum FilterType {
+  Pre = 0,
+  Main = 1
+}
+
 export interface FilterStatus {
   name: string;
   lifeLevel: number;
   code: string;
+  filterType: FilterType;
 }
 
 export interface Metadata {

--- a/src/lib/services/FilterService.ts
+++ b/src/lib/services/FilterService.ts
@@ -3,6 +3,7 @@ import { Config } from '../Config';
 import { HAP } from '../HAP';
 import { Service } from '../interfaces/HAP';
 import { AbstractService } from './AbstractService';
+import { FilterType } from '../interfaces/PurifierStatus';
 import { Logger } from '../Logger';
 
 export class FilterService extends AbstractService {
@@ -50,7 +51,7 @@ export class FilterService extends AbstractService {
 
   async getMainFilterChangeIndication(callback): Promise<void> {
     try {
-      const indication = await this.getChangeIndicationForFilter(Config.Filters.MAIN_FILTER_CODE);
+      const indication = await this.getChangeIndicationForFilter(FilterType.Main);
       callback(null, indication);
     } catch(e) {
       callback(e);
@@ -59,7 +60,7 @@ export class FilterService extends AbstractService {
 
   async getPreFilterChangeIndication(callback) {
     try {
-      const indication = await this.getChangeIndicationForFilter(Config.Filters.PRE_FILTER_CODE);
+      const indication = await this.getChangeIndicationForFilter(FilterType.Pre);
       callback(null, indication);
     } catch(e) {
       callback(e);
@@ -68,7 +69,7 @@ export class FilterService extends AbstractService {
 
   async getMainFilterLifeLevel(callback): Promise<void> {
     try {
-      const lifeLevel = await this.getLifeLevelForFilter(Config.Filters.MAIN_FILTER_CODE);
+      const lifeLevel = await this.getLifeLevelForFilter(FilterType.Main);
       callback(null, lifeLevel);
     } catch(e) {
       callback(e);
@@ -77,17 +78,17 @@ export class FilterService extends AbstractService {
 
   async getPreFilterLifeLevel(callback): Promise<void> {
     try {
-      const lifeLevel = await this.getLifeLevelForFilter(Config.Filters.PRE_FILTER_CODE);
+      const lifeLevel = await this.getLifeLevelForFilter(FilterType.Pre);
       callback(null, lifeLevel);
     } catch(e) {
       callback(e);
     }
   }
 
-  async getChangeIndicationForFilter(code: string): Promise<any> {
+  async getChangeIndicationForFilter(filterType: FilterType): Promise<any> {
     try {
       const status = await this.purifier.waitForFilterStatusUpdate();
-      const statusForFilter = status.find(filter => filter.code === code);
+      const statusForFilter = status.find(filter => filter.filterType === filterType);
       let indication;
 
       if (statusForFilter.lifeLevel <= 20) {
@@ -98,19 +99,20 @@ export class FilterService extends AbstractService {
 
       return indication;
     } catch(e) {
-      Logger.error(`Unable to get filter change indication for ${code}`, e);
+      Logger.error(`Unable to get filter change indication for ${FilterType[filterType.toString()]}`, e);
       throw e;
     }
   }
 
-  async getLifeLevelForFilter(code: string): Promise<number> {
+  async getLifeLevelForFilter(filterType: FilterType): Promise<number> {
     try {
       const status = await this.purifier.waitForFilterStatusUpdate();
-      const statusForFilter = status.find(filter => filter.code === code);
+      const statusForFilter = status.find(filter => filter.filterType === filterType);
 
+      Logger.debug(`Filter ${filterType} (type: ${FilterType[filterType.toString()]} name: '${statusForFilter.name}') life level is ${statusForFilter.lifeLevel}.`);
       return statusForFilter.lifeLevel;
     } catch(e) {
-      Logger.error(`Unable to get filter life level for ${code}`, e);
+      Logger.error(`Unable to get filter life level for ${FilterType[filterType.toString()]}`, e);
       throw e;
     }
   }


### PR DESCRIPTION
…er codes

Use the REST API's filter names (in Korean) to decide if it's a pre or main filter.

Note that the status response has a sort key that could also be used to determine pre/main, but that key isn't in the separate filter status response.