### PR TITLE
Possible fix for #7

### DIFF
--- a/src/lib/Client.ts
+++ b/src/lib/Client.ts
@@ -148,6 +148,7 @@ export class Client {
           comdVal: value,
           funcId: code,
         }],
+        mqttDevice: true,
       },
     };
 


### PR DESCRIPTION
This is meant to address issue #7, I had the same problem that others described and found that my IOCare app was sending an additional key/value pair in the payload to the iocareapp endpoint. When I added `mqttDevice: true` to the control payload the device responded to changes made in the Home app.

I'm not sure if this will break other versions of the 400S though, so it needs to be tested with a 400S that doesn't expect this key/value pair.